### PR TITLE
Prevent orphans in paged media

### DIFF
--- a/styles/application.css
+++ b/styles/application.css
@@ -514,6 +514,7 @@ section.rules_of_order h3[data-section] {
 body {
   orphans: 3;
   padding: 12pt 0;
+  widows: 3;
 }
 
 @page {

--- a/styles/application.css
+++ b/styles/application.css
@@ -512,6 +512,7 @@ section.rules_of_order h3[data-section] {
 -------------------------------------------------- */
 
 body {
+  orphans: 3;
   padding: 12pt 0;
 }
 


### PR DESCRIPTION
Twila mentioned that she needs to tweak PDFs in order to prevent orphans; a simple line of CSS can at least keep 3 lines together which should look better in any case