### PR TITLE
Fix list styles

### DIFF
--- a/styles/application.css
+++ b/styles/application.css
@@ -273,8 +273,16 @@ li {
 .list-number {
   display: table-cell;
   padding-right: 0.5rem;
-  width: 1rem;
+  text-align: right;
+  min-width: 1rem;
 }
+.list-number.lower-roman-bullet-prefix {
+  min-width: 1.5rem;
+}
+.list-number.upper-roman-bullet-prefix {
+  min-width: 2.5rem;
+}
+
 
 ol ol .list-number {
   text-align: right;

--- a/styles/application.css
+++ b/styles/application.css
@@ -274,13 +274,13 @@ li {
   display: table-cell;
   padding-right: 0.5rem;
   text-align: right;
-  min-width: 1rem;
+  width: 1rem;
 }
 .list-number.lower-roman-bullet-prefix {
-  min-width: 1.5rem;
+  width: 1.5rem;
 }
 .list-number.upper-roman-bullet-prefix {
-  min-width: 2.5rem;
+  width: 2.5rem;
 }
 
 


### PR DESCRIPTION
Roman numerals are wider and need more space
Numerals should be right-aligned
The fixed width of the list-number item should be changed into a min-width in case a large number won't fit