### PR TITLE
rem depends on font size in root element, so that must be known and d…

### DIFF
--- a/styles/application.css
+++ b/styles/application.css
@@ -3,20 +3,14 @@
 -------------------------------------------------- */
 
 html {
-  font-size: 9pt;
+  font-size: 9pt; /* rems depend on this setting */
   line-height: 1.5;
 }
 
 body {
-  line-height: 1.5;
+  font-family: Merriweather, serif;
   box-sizing: border-box;
   font-variant-ligatures: common-ligatures;
-}
-
-body,
-td,
-th {
-  font-family: Merriweather, serif;
   color: #000000;
 }
 
@@ -692,7 +686,7 @@ body {
   .constitution,
   .canons,
   .rules_of_order {
-    padding-right: 13rem !important;
+    padding-right: 2.2in !important;
   }
   section.title,
   section.intro,

--- a/styles/application.css
+++ b/styles/application.css
@@ -2,6 +2,11 @@
   GENERAL STYLES
 -------------------------------------------------- */
 
+html {
+  font-size: 9pt;
+  line-height: 1.5;
+}
+
 body {
   line-height: 1.5;
   box-sizing: border-box;
@@ -43,7 +48,8 @@ h6 {
 
 h1+p,
 h2+p,
-h3+p {
+h3+p,
+h4+ol {
   page-break-before: avoid;
 }
 
@@ -160,6 +166,12 @@ section.intro img {
 
 section.contents h2 {
   padding-top: 24pt;
+}
+section.contents h4 {
+  padding: 6pt 0;
+}
+section.contents li {
+  margin: 0;
 }
 
 a {
@@ -294,19 +306,8 @@ ol.upper-roman > li .list-number {
   margin-left: -4rem;
   width: 3.5rem;
 }
-
-
-ol ol .list-number {
-  text-align: right;
-}
-
-
 ol.sec-list > li p span.number {
   font-weight: bold;
-}
-
-.contents ol li {
-  margin: 3pt 0;
 }
 
 
@@ -317,6 +318,7 @@ ol.sec-list > li p span.number {
 .constitution ol dfn,
 .canons ol dfn,
 .rules_of_order ol dfn {
+  margin-top: 1.1pt;
   position: absolute;
   right: -1in;
   width: 0.85in;


### PR DESCRIPTION
Without a definition of font-size in the html element, we depend on browser and user settings.

Prevent page breaks after H4s, just like other H elements.

Correct vertical margins on table of contents, which changed after recent CSS changes to support hardcoded list item numbers.

Make baselines of sidebar text and first line of main text line up, for aesthetics.